### PR TITLE
fix format command does not run on macOS

### DIFF
--- a/clang-format.hook
+++ b/clang-format.hook
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+export PATH=$PATH:/usr/local/bin:/usr/local/sbin
+
 STYLE=$(git config --get hooks.clangformat.style)
 if [ -n "${STYLE}" ] ; then
   STYLEARG="-style=${STYLE}"


### PR DESCRIPTION
fix format command does not run on macOS and SourceTree
macOS clang-format from homebrew is installed "/usr/local/bin"