### PR TITLE
Apply clang-format only on existing files

### DIFF
--- a/clang-format.hook
+++ b/clang-format.hook
@@ -9,8 +9,10 @@ fi
 
 format_file() {
   file="${1}"
-  clang-format -i ${STYLEARG} ${1}
-  git add ${1}
+  if [ -f $file ]; then
+    clang-format -i ${STYLEARG} ${1}
+    git add ${1}
+  fi
 }
 
 case "${1}" in


### PR DESCRIPTION
Fix a problem when file was renamed/moved
https://github.com/andrewseidl/githook-clang-format/issues/5