### PR TITLE
Add filter to format c++ sources and headers only

### DIFF
--- a/clang-format.hook
+++ b/clang-format.hook
@@ -20,7 +20,7 @@ case "${1}" in
     echo "Runs clang-format on source files"
     ;;
   * )
-    for file in `git diff-index --cached --name-only HEAD` ; do
+    for file in `git diff-index --cached --name-only HEAD | grep -iE '\.(cpp|cc|h|hpp)' ` ; do
       format_file "${file}"
     done
     ;;


### PR DESCRIPTION
while using the pre-commit hook, I got lots of false formatting to my CMakeLists.txt changes, which is not expected. 
Therefore this commit is aiming to format source files only, instead of every changed file.