### PR TITLE
Update clang-format.hook

### DIFF
--- a/clang-format.hook
+++ b/clang-format.hook
@@ -20,7 +20,7 @@ case "${1}" in
     echo "Runs clang-format on source files"
     ;;
   * )
-    for file in `git diff-index --cached --name-only HEAD | grep -iE '\.(cpp|cc|h|hpp)' ` ; do
+    for file in `git diff-index --cached --name-only HEAD | grep -iE '\.(cpp|cc|h|hpp)$' ` ; do
       format_file "${file}"
     done
     ;;


### PR DESCRIPTION
Regular expression can erroneously match files with '.h', '.cc', '.cpp', or '.hpp' in the filename (i.e. myfile.h.something.else). This will ensure that only the file extension will be looked at.